### PR TITLE
Fix the typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@ title: Index
 					</p>
 				</li>
 				<li class="icon fa-headphones">
-					<h3>Intergrated Dell Remote Access Controller</h3>
+					<h3>Integrated Dell Remote Access Controller</h3>
 					<p>Embedded within every Dell EMC PowerEdge server is a powerful next-generation remote server management processor.<br />
 						<a target="_blank" href="https://www.delltechnologies.com/en-us/solutions/openmanage/idrac.htm">Explore iDRAC</a>
 					</p>


### PR DESCRIPTION
Quick fix on the typo on the front page of Code Hub.  