### PR TITLE
[SDPT-652] Add Helm Chart deployment instruction

### DIFF
--- a/_posts/Getting Started/2020-07-14-create-flink-project-on-streaming-data-platform.md
+++ b/_posts/Getting Started/2020-07-14-create-flink-project-on-streaming-data-platform.md
@@ -20,33 +20,33 @@ This is a general guide for creating and setting up Flink job on Dell EMC Stream
 Apache Flink is the embedded analytics engine in the Dell EMC Streaming Data Platform which provides a seamless way for development teams to deploy analytics applications. This post describes the general instruction of using Apache Flink<sup>®</sup> applications with the Streaming Data Platform.
 
 ## Instructions
-##### A. Remove `createScope` method from the code
-**1.** If you have used `createScope` method in Pravega standalone mode. Please **comment out** from your code since the SDP does not allow to create a scope from the code.
+##### 1. Remove `createScope` method from the code
+**A.** If you have used `createScope` method in Pravega standalone mode. Please **comment out** from your code since the SDP does not allow to create a scope from the code.
 
-##### B. Create Projects
-**1.** Log in to the Dell EMC Streaming Data Platform and click the **Analytics** icon to navigate to the Analytics Projects view which lists the projects you have access to. 
+##### 2. Create Projects
+**A.** Log in to the Dell EMC Streaming Data Platform and click the **Analytics** icon to navigate to the Analytics Projects view which lists the projects you have access to. 
 ![Analytics-Project]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/analytics-project.png)
 **Note:** If you cannot log in to the Dell EMC Streaming Data Platform, please use ```kubectl get ingress -A``` to find all ingress and add to your **/etc/hosts** file.  
 
-**2.** Click **Create Project** button to start with a new project by typing the project name, description and required volume size. This action will also automatically create a scope or namespace for your project in Pravega. 
+**B.** Click **Create Project** button to start with a new project by typing the project name, description and required volume size. This action will also automatically create a scope or namespace for your project in Pravega. 
 ![Create-Project]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/create-project.png)      
 
 
-##### C. Upload artifact to SDP
-###### Option I: Using the Dell EMC Streaming Data Platform UI
-**1.** Navigate to **Analytics > Analytics Projects > *project-name* > Artifacts**
+##### 3. Upload artifact to SDP
+###### Option A: Using the Dell EMC Streaming Data Platform UI
+**I.** Navigate to **Analytics > Analytics Projects > *project-name* > Artifacts**
 ![Artifact-UI]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/artifact-ui.png)
 
-**2.** Click **Upload Artifact**. Under the **General** section, specify the **Maven Group**, the **Maven Artifact**, and enter the **Version number**. Under the **Artifact** File section, browse to the JAR file on your local machine and select the file to upload to the repository. 
+**II.** Click **Upload Artifact**. Under the **General** section, specify the **Maven Group**, the **Maven Artifact**, and enter the **Version number**. Under the **Artifact** File section, browse to the JAR file on your local machine and select the file to upload to the repository. 
 ![Upload-Artifact]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/upload-artifact.png)
 
-###### Option II: Using the Gradle Build Tool
-**1.** Make the Maven repo in SDP available to your development workstation.
+###### Option B: Using the Gradle Build Tool
+**I.** Make the Maven repo in SDP available to your development workstation.
 ```
 kubectl port-forward service/repo 9090:80 --namespace project-name
 ```
 
-**2.** Add a publishing section to your `build.gradle` file. The standard `maven-publish` Gradle plugin must be added to the project in addition to a credentials section. You may also need to customize the publication identity, such as **groupId**, **artifactId**, and **version**. If you publish shadow JARs, make sure to add `classifier = ""` and `zip64 true` to the `shadowJar` config. The following is an example `build.gradle` file.
+**II.** Add a publishing section to your `build.gradle` file. The standard `maven-publish` Gradle plugin must be added to the project in addition to a credentials section. You may also need to customize the publication identity, such as **groupId**, **artifactId**, and **version**. If you publish shadow JARs, make sure to add `classifier = ""` and `zip64 true` to the `shadowJar` config. The following is an example `build.gradle` file.
 ```
 apply plugin: "maven-publish"
 publishing {
@@ -74,38 +74,33 @@ publishing {
 }
 ```
 
-**3.** Use the Gradle Extension either from  IntelliJ IDEA or [Command-Line Interface](https://docs.gradle.org/current/userguide/command_line_interface.html) to publish the application JAR file to SDP.
+**III.** Use the Gradle Extension either from  IntelliJ IDEA or [Command-Line Interface](https://docs.gradle.org/current/userguide/command_line_interface.html) to publish the application JAR file to SDP.
 
 
-##### Next, you need to create the Flink Clusters, and deploy the applications. There are two ways to complete the above tasks, through the UI on SDP or using [Helm Charts](https://helm.sh/docs/topics/charts/#:~:text=Helm%20uses%20a%20packaging%20format,%2C%20caches%2C%20and%20so%20on). 
+#####  4. Create Flink Clusters and Deploy Applications 
 
-####  <span style="color:#0076ce">Option A: Using Dell EMC Streaming Data Platform UI</span> 
+###### Next, you need to create the Flink Clusters, and deploy the applications. There are two ways to complete the above tasks, through the UI on SDP or using [Helm Charts](https://helm.sh/docs/topics/charts/#:~:text=Helm%20uses%20a%20packaging%20format,%2C%20caches%2C%20and%20so%20on). 
 
-#####  D. Create Flink Clusters
-**1.** To create a Flink cluster using the Dell EMC Streaming Data Platform UI, navigate to **Analytics -> *project-name* > Flink Clusters**.  
+#####  <span style="color:#0076ce">Option A: Using Dell EMC Streaming Data Platform UI</span> 
+**I.** To create a Flink cluster using the Dell EMC Streaming Data Platform UI, navigate to **Analytics -> *project-name* > Flink Clusters**.  
 ![Flink-Cluster]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/flink-cluster.png)
 
-**2.** Click **Create Flink Cluster** and complete the cluster configuration fields.
+**II.** Click **Create Flink Cluster** and complete the cluster configuration fields.
 ![Create-Flink-Cluster]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/create-flink-cluster.png)
 
-
-
-##### E. Deploy Applications
-**1.** Navigate to **Analytics > Analytics Projects > *project-name* > Apps**
+**III.** Navigate to **Analytics > Analytics Projects > *project-name* > Apps**
 ![App-UI]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/app.png)
 
-**2.**  Click **Create New App**. Specify the application name, the artifact source, main class, and other configuration information. You also have the chance to create a new Pravega stream for your application.
+**IV.**  Click **Create New App**. Specify the application name, the artifact source, main class, and other configuration information. You also have the chance to create a new Pravega stream for your application.
 ![Create-App]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/create-app.png)
 
-####  <span style="color:#0076ce">Option B: Using Helm Chart to deploy the application</span> 
+#####  <span style="color:#0076ce">Option B: Using Helm Chart to deploy the application</span> 
 
-#####  D. Create the Chart File Structure and add `yaml` files to the template
-
-**1.** Install **[Helm CLI](https://helm.sh/docs/intro/install/)** into your local development environment.
+**I.** Install **[Helm CLI](https://helm.sh/docs/intro/install/)** into your local development environment.
 
 Follow [this guide](https://helm.sh/docs/intro/install/) to install Helm. It can be installed either from source, or from pre-built binary releases.
 
-**2.** Generate the **[Helm Chart](https://helm.sh/docs/topics/charts/)** file structure  
+**II.** Generate the **[Helm Chart](https://helm.sh/docs/topics/charts/)** file structure  
 To use Helm Chart, you need to have a collection of files inside a directory. The directory should be named as `charts`. Then refer to [this github repo](https://github.com/pravega/workshop-samples/tree/master/charts), the [Helm Charts documentation](https://helm.sh/docs/topics/charts/), and the following structure to organize your Chart file.  
 
 ```
@@ -115,7 +110,7 @@ charts/               # A directory containing any charts upon which this chart 
   templates/          # A directory of templates that, when combined with values,
                       # will generate valid Kubernetes manifest files.
 ```
-**3.** Add **FlinkCluster** and **application** `yaml` files to the `template` folder.  
+**III.** Add **FlinkCluster** and **application** `yaml` files to the `template` folder.  
 Next, you need to create template `yaml` files to generate manifest files on the Kubernetes cluster, combining with the configuration in `values.yaml`.
 
 The template folder in [workshop-sample repo](https://github.com/pravega/workshop-samples/tree/master/charts/templates) will give you a general idea for developing your template file. Your chart file structure should look similar to the following way.
@@ -125,15 +120,14 @@ charts/
   Chart.yaml          
   values.yaml         
   templates/          
-    FlinkCluster.yaml               # Template file for Flink Cluste
+    FlinkCluster.yaml               # Template file for Flink Cluster
     YourApplication.yaml            # Template file for your application. It can be multiple applications.
             ...
             ...
             ...                    
 ```
 
-##### E. Deploy Applications
-**1.** Go to your project home directory  
+**IV.** Go to your project home directory  
 Since all chart files have been organized into a structure  under the `Charts` folder, you need to visit the parent directory of `Chart` folder in order to install or upgrade the Helm Chart to SDP. 
 
 Take the following structure as an example; after this step, you should locate inside the `FlinkApp` folder.
@@ -144,7 +138,7 @@ FlinkApp/
         Chart.yaml          
         values.yaml         
         templates/          
-            FlinkCluster.yaml               # Template file for Flink Cluste
+            FlinkCluster.yaml               # Template file for Flink Cluster
             YourApplication.yaml            # Template file for your application. It can be multiple applications.
                     ...
                     ...
@@ -152,7 +146,7 @@ FlinkApp/
     FlinkApplication/                 
 ```
 
-**2.**  Using **[Helm CLI](https://helm.sh/docs/intro/quickstart/)** to install or upgrade the charts  
+**V.**  Using **[Helm CLI](https://helm.sh/docs/intro/quickstart/)** to install or upgrade the charts  
 
 Open the terminal window from the project home directory that you access from the above step. Then you can use either [`helm install`](https://helm.sh/docs/helm/helm_install/) or [`helm upgrade`](https://helm.sh/docs/helm/helm_upgrade/) command to deploy your application and charts to SDP. 
 
@@ -168,8 +162,8 @@ helm upgrade --install --timeout 600s jsonreader --wait --namespace workshop-sam
 ```
 
 
-##### F. Check Project Status
-**1.** Navigate to **Analytics > Analytics Projects > *project-name***. Use the links at the top of the project dashboard to view Apache Flink clusters, applications, and artifacts associated with the project.
+##### 5. Check Project Status
+**A.** Navigate to **Analytics > Analytics Projects > *project-name***. Use the links at the top of the project dashboard to view Apache Flink clusters, applications, and artifacts associated with the project.
 ![Dashboard-UI]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/dashboard.png)
 
 

--- a/_posts/Getting Started/2020-07-14-create-flink-project-on-streaming-data-platform.md
+++ b/_posts/Getting Started/2020-07-14-create-flink-project-on-streaming-data-platform.md
@@ -52,7 +52,7 @@ NAME   HOSTS                                ADDRESS        PORTS   AGE
 repo   repo.your-namespace.host.com       11.111.11.11      80     24h
 ```
 
-Then find and open the `hosts` files which location, depending on the operating system that you are using, is: 
+If necessary, you may need to make changes to your `hosts` file. In order to so, find and open the `hosts` files which location, depending on the operating system that you are using, is: 
 - Windows - `C:\Windows\System32\drivers\etc\hosts`
 - Linux - `/etc/hosts`
 
@@ -72,7 +72,7 @@ root@ubuntu:~$ cat /etc/hosts
 
 The standard `maven-publish` Gradle plugin must be added to the project in addition to a credentials section. The following is an example `build.gradle` file.
 
-Make sure to change the `host` and `protocol` in url to the corresponding information you get from the above step. Depending on the port number, the url protocol is:
+Make sure to change the `url` to the corresponding information you get from the above step. Depending on the port number, the url protocol is:
 - `80` : http
 - `443` : https 
 
@@ -85,7 +85,7 @@ apply plugin: "maven-publish"
 publishing {
     repositories {
         maven {
-            url = "http://host/maven2"
+            url = "http://repo.your-namespace.host.com/maven2"
             credentials {
             username "johndoe"
             password "**********"

--- a/_posts/Getting Started/2020-07-14-create-flink-project-on-streaming-data-platform.md
+++ b/_posts/Getting Started/2020-07-14-create-flink-project-on-streaming-data-platform.md
@@ -32,7 +32,10 @@ Apache Flink is the embedded analytics engine in the Dell EMC Streaming Data Pla
 ![Create-Project]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/create-project.png)      
 
 
-##### 3. Upload artifact to SDP
+##### 3. Upload Flink artifact to SDP
+
+You must have all your artifact available on the SDP maven repository. There are two different ways for uploading your Flink job artifact:   
+
 ###### Option A: Using the Dell EMC Streaming Data Platform UI
 **I.** Navigate to **Analytics > Analytics Projects > *project-name* > Artifacts**
 ![Artifact-UI]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/artifact-ui.png)
@@ -54,8 +57,8 @@ publishing {
         maven {
             url = "http://localhost:9090/maven2"
             credentials {
-            username "desdp"
-            password "password"
+            username "johndoe"
+            password "**********"
             }
             authentication {
                 basic(BasicAuthentication)
@@ -105,59 +108,58 @@ To use Helm Chart, you need to have a collection of files inside a directory. Th
 
 ```
 charts/               # A directory containing any charts upon which this chart depends
-  Chart.yaml          # A YAML file containing information about the chart
-  values.yaml         # The default configuration values for this chart
-  templates/          # A directory of templates that, when combined with values,
-                      # will generate valid Kubernetes manifest files.
+    AplicationName/         # This structure will allow one application per cluster
+        Chart.yaml          # A YAML file containing information about the chart
+        values.yaml         # The default configuration values for this chart
+        templates/          # A directory of templates that, when combined with values,
+                            # will generate valid Kubernetes manifest files.
 ```
 **III.** Add **FlinkCluster** and **application** `yaml` files to the `template` folder.  
 Next, you need to create template `yaml` files to generate manifest files on the Kubernetes cluster, combining with the configuration in `values.yaml`.
 
-The template folder in [workshop-sample repo](https://github.com/pravega/workshop-samples/tree/master/charts/templates) will give you a general idea for developing your template file. Your chart file structure should look similar to the following way.
+The template folder in [workshop-sample repo](https://github.com/pravega/workshop-samples/tree/master/charts/templates) will give you a general idea for developing your template file. We highly recommend one application per cluster. Once the application has been developed and tested in isolation, advanced users can optimize resources by sharing clusters. Your chart file structure should look similar to the following when using one application per cluster.
 
 ```
 charts/              
-  Chart.yaml          
-  values.yaml         
-  templates/          
-    FlinkCluster.yaml               # Template file for Flink Cluster
-    YourApplication.yaml            # Template file for your application. It can be multiple applications.
-            ...
-            ...
-            ...                    
+    TestApplication/
+        Chart.yaml          
+        values.yaml         
+        templates/          
+            FlinkCluster.yaml               # Template file for Flink Cluster
+            FlinkApplication.yaml           # Template file for your application. 
+    ...
+    ...                                     # You can have multiple applications.
+    ...                     
 ```
 
 **IV.** Go to your project home directory  
-Since all chart files have been organized into a structure  under the `Charts` folder, you need to visit the parent directory of `Chart` folder in order to install or upgrade the Helm Chart to SDP. 
+Since all chart files have been organized into a structure under the `charts` folder, you need to visit the parent directory of `charts` folder in order to install or upgrade the Helm Chart to SDP. 
 
 Take the following structure as an example; after this step, you should locate inside the `FlinkApp` folder.
 
 ```
 FlinkApp/
     charts/              
-        Chart.yaml          
-        values.yaml         
-        templates/          
-            FlinkCluster.yaml               # Template file for Flink Cluster
-            YourApplication.yaml            # Template file for your application. It can be multiple applications.
-                    ...
-                    ...
-                    ...   
-    FlinkApplication/                 
+        TestApplication/
+            Chart.yaml          
+            values.yaml         
+            templates/          
+                FlinkCluster.yaml               # Template file for Flink Cluster
+                FlinkApplication.yaml           # Template file for your application. 
+        ...
+        ...                                     # You can have multiple applications.
+        ...   
+    TestApplication/                 
 ```
 
 **V.**  Using **[Helm CLI](https://helm.sh/docs/intro/quickstart/)** to install or upgrade the charts  
 
-Open the terminal window from the project home directory that you access from the above step. Then you can use either [`helm install`](https://helm.sh/docs/helm/helm_install/) or [`helm upgrade`](https://helm.sh/docs/helm/helm_upgrade/) command to deploy your application and charts to SDP. 
+Open the terminal window from the project home directory that you access from the above step. Then you can use [`helm upgrade`](https://helm.sh/docs/helm/helm_upgrade/) command to deploy your application and charts to SDP. 
 
 The following are the command examples that will create a release name `jsonreader`. The benefit of using  [`helm upgrade`](https://helm.sh/docs/helm/helm_upgrade/) is that if a release by this name doesn't already exist, it will automatically run an install; otherwise, it will upgrade a release to a new version of a chart.
 
 
 ```
-helm install --timeout 600s jsonreader --wait --namespace workshop-samples charts
-
-// Or
-
 helm upgrade --install --timeout 600s jsonreader --wait --namespace workshop-samples charts
 ```
 

--- a/_posts/Getting Started/2020-07-14-create-flink-project-on-streaming-data-platform.md
+++ b/_posts/Getting Started/2020-07-14-create-flink-project-on-streaming-data-platform.md
@@ -3,6 +3,7 @@ layout: post
 category: "Getting Started"
 tags: [flink, java, SDP, Pravega]
 subtitle: "Create Projects and Flink Clusters on Dell EMC Streaming Data Platform"
+technologies: [SDP, Flink] 
 img: sdp.jpg
 license: Apache
 support: Community
@@ -44,18 +45,47 @@ You must have all your artifact available on the SDP maven repository. There are
 ![Upload-Artifact]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/upload-artifact.png)
 
 ###### Option B: Using the Gradle Build Tool
-**I.** Make the Maven repo in SDP available to your development workstation.
+**I.** Make the Maven repo in SDP available to your development workstation. Use `kubectl ingress` command to get the host and IP address for your namespace repo.
 ```
-kubectl port-forward service/repo 9090:80 --namespace project-name
+root@ubuntu:~$ kubectl get ingress -n your-namespace
+NAME   HOSTS                                ADDRESS        PORTS   AGE
+repo   repo.your-namespace.host.com       11.111.11.11      80     24h
 ```
 
-**II.** Add a publishing section to your `build.gradle` file. The standard `maven-publish` Gradle plugin must be added to the project in addition to a credentials section. You may also need to customize the publication identity, such as **groupId**, **artifactId**, and **version**. If you publish shadow JARs, make sure to add `classifier = ""` and `zip64 true` to the `shadowJar` config. The following is an example `build.gradle` file.
+Then find and open the `hosts` files which location, depending on the operating system that you are using, is: 
+- Windows - `C:\Windows\System32\drivers\etc\hosts`
+- Linux - `/etc/hosts`
+
+Use [`vim`](https://www.vim.org/), [`Sublime Text`](https://www.sublimetext.com/), or any other text editors to add the host and IP address information to the `hosts` file.  
+After this step, you should find a similar entry from your `hosts` file as following.   
+```
+root@ubuntu:~$ cat /etc/hosts
+    ...                           ...
+    ...                           ...  
+    ...                           ...          
+    ...                           ...
+11.111.11.11          repo.your-namespace.host.com
+```
+
+
+**II.** Add a publishing section to your `build.gradle` file. 
+
+The standard `maven-publish` Gradle plugin must be added to the project in addition to a credentials section. The following is an example `build.gradle` file.
+
+Make sure to change the `host` and `protocol` in url to the corresponding information you get from the above step. Depending on the port number, the url protocol is:
+- `80` : http
+- `443` : https 
+
+Then replace the default `username` and `password` with your credential information.   
+You may also need to customize the publication identity, such as **groupId**, **artifactId**, and **version**. If you publish shadow JARs, make sure to add `classifier = ""` and `zip64 true` to the `shadowJar` config. 
+
+
 ```
 apply plugin: "maven-publish"
 publishing {
     repositories {
         maven {
-            url = "http://localhost:9090/maven2"
+            url = "http://host/maven2"
             credentials {
             username "johndoe"
             password "**********"

--- a/_posts/Getting Started/2020-07-14-create-flink-project-on-streaming-data-platform.md
+++ b/_posts/Getting Started/2020-07-14-create-flink-project-on-streaming-data-platform.md
@@ -28,17 +28,11 @@ Apache Flink is the embedded analytics engine in the Dell EMC Streaming Data Pla
 ![Analytics-Project]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/analytics-project.png)
 **Note:** If you cannot log in to the Dell EMC Streaming Data Platform, please use ```kubectl get ingress -A``` to find all ingress and add to your **/etc/hosts** file.  
 
-**2.** Click **Create Project** button to start with a new project by typing the project name, description and required volume size. This will also automatically create a scope or namespace for your project in Pravega. 
-![Create-Project]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/create-project.png)
+**2.** Click **Create Project** button to start with a new project by typing the project name, description and required volume size. This action will also automatically create a scope or namespace for your project in Pravega. 
+![Create-Project]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/create-project.png)      
 
-##### C. Create Flink Clusters
-**1.** To create a Flink cluster using the Dell EMC Streaming Data Platform UI, navigate to **Analytics -> *project-name* > Flink Clusters**.  
-![Flink-Cluster]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/flink-cluster.png)
 
-**2.** Click **Create Flink Cluster** and complete the cluster configuration fields.
-![Create-Flink-Cluster]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/create-flink-cluster.png)
-
-##### D. Upload artifact to SDP
+##### C. Upload artifact to SDP
 ###### Option I: Using the Dell EMC Streaming Data Platform UI
 **1.** Navigate to **Analytics > Analytics Projects > *project-name* > Artifacts**
 ![Artifact-UI]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/artifact-ui.png)
@@ -52,7 +46,7 @@ Apache Flink is the embedded analytics engine in the Dell EMC Streaming Data Pla
 kubectl port-forward service/repo 9090:80 --namespace project-name
 ```
 
-**2.** Add a publishing section to your `build.gradle` file. The standard `maven-publish` Gradle plugin must be added to the project in addition to a credentials section. You may also need to customize the publication identity, such as **groupId**, **artifactId**, and **version**. If you publish shadow JARs, make sure add `classifier = ""` and `zip64 true` to the `shadowJar` config. The following is an example `build.gradle` file.
+**2.** Add a publishing section to your `build.gradle` file. The standard `maven-publish` Gradle plugin must be added to the project in addition to a credentials section. You may also need to customize the publication identity, such as **groupId**, **artifactId**, and **version**. If you publish shadow JARs, make sure to add `classifier = ""` and `zip64 true` to the `shadowJar` config. The following is an example `build.gradle` file.
 ```
 apply plugin: "maven-publish"
 publishing {
@@ -82,12 +76,97 @@ publishing {
 
 **3.** Use the Gradle Extension either from  IntelliJ IDEA or [Command-Line Interface](https://docs.gradle.org/current/userguide/command_line_interface.html) to publish the application JAR file to SDP.
 
+
+##### Next, you need to create the Flink Clusters, and deploy the applications. There are two ways to complete the above tasks, through the UI on SDP or using [Helm Charts](https://helm.sh/docs/topics/charts/#:~:text=Helm%20uses%20a%20packaging%20format,%2C%20caches%2C%20and%20so%20on). 
+
+####  <span style="color:#0076ce">Option A: Using Dell EMC Streaming Data Platform UI</span> 
+
+#####  D. Create Flink Clusters
+**1.** To create a Flink cluster using the Dell EMC Streaming Data Platform UI, navigate to **Analytics -> *project-name* > Flink Clusters**.  
+![Flink-Cluster]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/flink-cluster.png)
+
+**2.** Click **Create Flink Cluster** and complete the cluster configuration fields.
+![Create-Flink-Cluster]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/create-flink-cluster.png)
+
+
+
 ##### E. Deploy Applications
 **1.** Navigate to **Analytics > Analytics Projects > *project-name* > Apps**
 ![App-UI]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/app.png)
 
 **2.**  Click **Create New App**. Specify the application name, the artifact source, main class, and other configuration information. You also have the chance to create a new Pravega stream for your application.
 ![Create-App]({{site.baseurl}}/assets/heliumjk/images/post/flink-sdp-setup/create-app.png)
+
+####  <span style="color:#0076ce">Option B: Using Helm Chart to deploy the application</span> 
+
+#####  D. Create the Chart File Structure and add `yaml` files to the template
+
+**1.** Install **[Helm CLI](https://helm.sh/docs/intro/install/)** into your local development environment.
+
+Follow [this guide](https://helm.sh/docs/intro/install/) to install Helm. It can be installed either from source, or from pre-built binary releases.
+
+**2.** Generate the **[Helm Chart](https://helm.sh/docs/topics/charts/)** file structure  
+To use Helm Chart, you need to have a collection of files inside a directory. The directory should be named as `charts`. Then refer to [this github repo](https://github.com/pravega/workshop-samples/tree/master/charts), the [Helm Charts documentation](https://helm.sh/docs/topics/charts/), and the following structure to organize your Chart file.  
+
+```
+charts/               # A directory containing any charts upon which this chart depends
+  Chart.yaml          # A YAML file containing information about the chart
+  values.yaml         # The default configuration values for this chart
+  templates/          # A directory of templates that, when combined with values,
+                      # will generate valid Kubernetes manifest files.
+```
+**3.** Add **FlinkCluster** and **application** `yaml` files to the `template` folder.  
+Next, you need to create template `yaml` files to generate manifest files on the Kubernetes cluster, combining with the configuration in `values.yaml`.
+
+The template folder in [workshop-sample repo](https://github.com/pravega/workshop-samples/tree/master/charts/templates) will give you a general idea for developing your template file. Your chart file structure should look similar to the following way.
+
+```
+charts/              
+  Chart.yaml          
+  values.yaml         
+  templates/          
+    FlinkCluster.yaml               # Template file for Flink Cluste
+    YourApplication.yaml            # Template file for your application. It can be multiple applications.
+            ...
+            ...
+            ...                    
+```
+
+##### E. Deploy Applications
+**1.** Go to your project home directory  
+Since all chart files have been organized into a structure  under the `Charts` folder, you need to visit the parent directory of `Chart` folder in order to install or upgrade the Helm Chart to SDP. 
+
+Take the following structure as an example; after this step, you should locate inside the `FlinkApp` folder.
+
+```
+FlinkApp/
+    charts/              
+        Chart.yaml          
+        values.yaml         
+        templates/          
+            FlinkCluster.yaml               # Template file for Flink Cluste
+            YourApplication.yaml            # Template file for your application. It can be multiple applications.
+                    ...
+                    ...
+                    ...   
+    FlinkApplication/                 
+```
+
+**2.**  Using **[Helm CLI](https://helm.sh/docs/intro/quickstart/)** to install or upgrade the charts  
+
+Open the terminal window from the project home directory that you access from the above step. Then you can use either [`helm install`](https://helm.sh/docs/helm/helm_install/) or [`helm upgrade`](https://helm.sh/docs/helm/helm_upgrade/) command to deploy your application and charts to SDP. 
+
+The following are the command examples that will create a release name `jsonreader`. The benefit of using  [`helm upgrade`](https://helm.sh/docs/helm/helm_upgrade/) is that if a release by this name doesn't already exist, it will automatically run an install; otherwise, it will upgrade a release to a new version of a chart.
+
+
+```
+helm install --timeout 600s jsonreader --wait --namespace workshop-samples charts
+
+// Or
+
+helm upgrade --install --timeout 600s jsonreader --wait --namespace workshop-samples charts
+```
+
 
 ##### F. Check Project Status
 **1.** Navigate to **Analytics > Analytics Projects > *project-name***. Use the links at the top of the project dashboard to view Apache Flink clusters, applications, and artifacts associated with the project.

--- a/_posts/Getting Started/2020-07-14-create-flink-project-on-streaming-data-platform.md
+++ b/_posts/Getting Started/2020-07-14-create-flink-project-on-streaming-data-platform.md
@@ -113,6 +113,7 @@ Replace the default `MAVEN_USER` and `MAVEN_PASSWORD` with the same credentials 
 export MAVEN_USER=johndoe  
 export MAVEN_PASSWORD=**********
 ```
+
 **IV.** Use the Gradle Extension either from  IntelliJ IDEA or [Command-Line Interface](https://docs.gradle.org/current/userguide/command_line_interface.html) to publish the application JAR file to SDP.
 
 
@@ -210,7 +211,7 @@ FlinkApp/
 
 Open the terminal window from the project home directory that you access from the above step. Then you can use [`helm upgrade`](https://helm.sh/docs/helm/helm_upgrade/) command to deploy your application and charts to SDP. The benefit of using  [`helm upgrade`](https://helm.sh/docs/helm/helm_upgrade/) is that if a release by this name doesn't already exist, it will automatically run an install; otherwise, it will upgrade a release to a new version of a chart.
 
-Make sure to replace the `release name`, `path to project charts`, `namesapce`, and `path to application values file` with appropriate values.
+Make sure to replace the `release name`, `path to project charts`, `namespace`, and `path to application values file` with appropriate values.
 ```
 ./gradlew publish
 helm upgrade --install --timeout 600s --wait \


### PR DESCRIPTION
For this PR, I add a section of the helm chart deployment process to the post [Create Flink Project On Streaming Data Platform](https://streamingdataplatform.github.io/code-hub/getting%20started/2020/07/14/create-flink-project-on-streaming-data-platform.html).

Signed-off-by: Youmin Han <Youmin.Han@dell.com>